### PR TITLE
Implement admin dashboard stats

### DIFF
--- a/project/src/AdminPage.tsx
+++ b/project/src/AdminPage.tsx
@@ -75,6 +75,25 @@ const LoginFormPortal: React.FC<{
       }
     };
   }, []);
+
+  // ログイン後に統計情報を取得
+  useEffect(() => {
+    const fetchStats = async () => {
+      if (!isLoggedIn) return;
+      try {
+        const res = await api.get('/admin/stats');
+        setStats({
+          newsCount: res.data.newsCount,
+          scheduleCount: res.data.scheduleCount,
+          mediaCount: res.data.mediaCount,
+          userCount: res.data.userCount,
+        });
+      } catch (err) {
+        console.error('Stats fetch error:', err);
+      }
+    };
+    fetchStats();
+  }, [isLoggedIn]);
   
   // ポータルのマークアップ
   const portalContent = (
@@ -179,6 +198,7 @@ const AdminPage: React.FC = () => {
   const [apiConnected, setApiConnected] = useState<boolean | null>(null);
   const navigate = useNavigate();
   const [user, setUser] = useState<any>(null);
+  const [stats, setStats] = useState({ newsCount: 0, scheduleCount: 0, mediaCount: 0, userCount: 0 });
 
   // API接続確認
   useEffect(() => {
@@ -324,23 +344,24 @@ const AdminPage: React.FC = () => {
           <div className="bg-white rounded-lg shadow p-6">
             <h3 className="text-gray-500 text-sm font-medium mb-2">公開中のニュース</h3>
             <div className="flex items-end">
-              <span className="text-3xl font-bold text-gray-800">5</span>
+              <span className="text-3xl font-bold text-gray-800">{stats.newsCount}</span>
               <span className="text-sm text-green-600 ml-2">公開中</span>
             </div>
           </div>
-          
+
           <div className="bg-white rounded-lg shadow p-6">
             <h3 className="text-gray-500 text-sm font-medium mb-2">登録中のレッスン</h3>
             <div className="flex items-end">
-              <span className="text-3xl font-bold text-gray-800">24</span>
+              <span className="text-3xl font-bold text-gray-800">{stats.scheduleCount}</span>
               <span className="text-sm text-gray-600 ml-2">クラス</span>
             </div>
           </div>
-          
+
           <div className="bg-white rounded-lg shadow p-6">
-            <h3 className="text-gray-500 text-sm font-medium mb-2">最終更新日</h3>
+            <h3 className="text-gray-500 text-sm font-medium mb-2">登録メディア数</h3>
             <div className="flex items-end">
-              <span className="text-lg font-bold text-gray-800">{new Date().toLocaleDateString('ja-JP')}</span>
+              <span className="text-3xl font-bold text-gray-800">{stats.mediaCount}</span>
+              <span className="text-sm text-gray-600 ml-2">件</span>
             </div>
           </div>
         </div>

--- a/server/controllers/admin.ts
+++ b/server/controllers/admin.ts
@@ -1,0 +1,22 @@
+import { Response } from 'express';
+import News from '../models/News';
+import Schedule from '../models/Schedule';
+import Media from '../models/Media';
+import User from '../models/User';
+import { AuthRequest } from '../middleware/auth';
+
+export const getStats = async (req: AuthRequest, res: Response) => {
+  try {
+    const [newsCount, scheduleCount, mediaCount, userCount] = await Promise.all([
+      News.countDocuments(),
+      Schedule.countDocuments(),
+      Media.countDocuments(),
+      User.countDocuments()
+    ]);
+
+    res.json({ newsCount, scheduleCount, mediaCount, userCount });
+  } catch (error) {
+    console.error('Admin stats error:', error);
+    res.status(500).json({ error: 'サーバーエラーが発生しました' });
+  }
+};

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import { authenticate, isAdmin } from '../middleware/auth';
+import { getStats } from '../controllers/admin';
+
+const router = express.Router();
+
+router.get('/stats', authenticate as any, isAdmin as any, getStats as any);
+
+export default router;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -15,6 +15,7 @@ import authRoutes from '../routes/auth';
 import newsRoutes from '../routes/news';
 import scheduleRoutes from '../routes/schedule';
 import mediaRoutes from '../routes/media';
+import adminRoutes from '../routes/admin';
 
 // Expressアプリケーション作成
 const app = express();
@@ -56,6 +57,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/news', newsRoutes);
 app.use('/api/schedule', scheduleRoutes);
 app.use('/api/media', mediaRoutes);
+app.use('/api/admin', adminRoutes);
 
 // ヘルスチェックエンドポイント
 app.get('/api/health', (req, res) => {


### PR DESCRIPTION
## Summary
- provide backend endpoint for admin dashboard statistics
- expose new admin route in server
- fetch stats in admin dashboard
- show counts for news, schedule, and media

## Testing
- `npm run lint --prefix project` *(fails: Cannot find package '@eslint/js')*
- `npm run build --silent` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6849c56b441483339e56f86b8278ec54