### PR TITLE
Set admin default credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ PORT=5000
 MONGODB_URI=mongodb://localhost:27017/moriwaki_ballet
 JWT_SECRET=あなたの秘密鍵
 NODE_ENV=development
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=admin
 ```
 
 4. フロントエンド用の環境変数を設定
@@ -86,7 +88,9 @@ POST http://localhost:5000/api/auth/init-admin
 
 デフォルトの認証情報：
 - ユーザー名: admin
-- パスワード: moriwaki2023
+- パスワード: admin
+
+本番環境では、環境変数 `ADMIN_USERNAME` と `ADMIN_PASSWORD` が設定されていない場合、上記のデフォルト値が使用されます。
 
 **注意**: 本番環境ではこの機能は無効になります。
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,6 +16,34 @@ import newsRoutes from '../routes/news';
 import scheduleRoutes from '../routes/schedule';
 import mediaRoutes from '../routes/media';
 import adminRoutes from '../routes/admin';
+import User from '../models/User';
+
+// 管理者アカウントを初期化
+const ensureAdminUser = async () => {
+  const username = process.env.ADMIN_USERNAME || 'admin';
+  const password = process.env.ADMIN_PASSWORD || 'admin';
+  const email = process.env.ADMIN_EMAIL || 'admin@example.com';
+
+  let admin = await User.findOne({ role: 'admin' });
+
+  if (!admin) {
+    admin = new User({
+      username,
+      password,
+      name: '管理者',
+      email,
+      role: 'admin'
+    });
+    await admin.save();
+    console.log('Admin account created');
+  } else {
+    admin.username = username;
+    admin.password = password;
+    admin.email = email;
+    await admin.save();
+    console.log('Admin account updated');
+  }
+};
 
 // Expressアプリケーション作成
 const app = express();
@@ -102,8 +130,9 @@ const mongooseOptions = {
 };
 
 mongoose.connect(mongoUri)
-  .then(() => {
+  .then(async () => {
     console.log('MongoDB connected successfully');
+    await ensureAdminUser();
   })
   .catch(err => {
     console.error('MongoDB connection error:', err);


### PR DESCRIPTION
## Summary
- set default admin credentials via env vars
- document new admin credentials in setup section
- ensure admin user is created/updated on server start

## Testing
- `npm run build` *(fails: cannot access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_685805be0ae88333aea169c03893ae69